### PR TITLE
Fixing memory leaks

### DIFF
--- a/addon/components/simple-mde.js
+++ b/addon/components/simple-mde.js
@@ -102,9 +102,14 @@ export default Ember.TextArea.extend({
     ));
     this.get('currentEditor').value(this.get('value') || '');
 
-    this.get('currentEditor').codemirror.on('change', () => {
+    this.get('currentEditor').codemirror.on('change', () => Ember.run.once(this, function() {
       this.sendAction('change', this.get('currentEditor').value());
-    });
+    }));
+  },
+
+  willDestroyElement() {
+    this.get('currentEditor').toTextArea();
+    this.set('currentEditor', null);
   },
 
   /**


### PR DESCRIPTION
Codemirror instance was not destroyed with wrapper component which is memory leak. In addition to that ember will throws errors about modifying the data twice in one single render loop as the callback from codemirror is not wrapped in ember run loop.